### PR TITLE
Урок 3. Средства ввода-вывода

### DIFF
--- a/client/src/main/java/client/Controller.java
+++ b/client/src/main/java/client/Controller.java
@@ -88,6 +88,18 @@ public class Controller implements Initializable {
         setAuthenticated(false);
     }
 
+    private void loadHistory(String logFileName) throws IOException {
+        try {
+            List<String> history = Files.readAllLines(Paths.get(logFileName), Charset.forName("UTF-8"));
+            int start = history.size() > 100 ? history.size() - 100 : 0;
+            for (int i = start; i < history.size(); i++) {
+                textArea.appendText(history.get(i) + "\n");
+            }
+        } catch (NoSuchFileException e) {
+
+        }
+    }
+
     private void connect() {
         try {
             socket = new Socket(IP_ADDRESS, PORT);
@@ -119,15 +131,7 @@ public class Controller implements Initializable {
                     }
                     //цикл работы
                     String fileName = String.format("history_%s.txt", nickname);
-                    try {
-                        List<String> history = Files.readAllLines(Paths.get(fileName), Charset.forName("UTF-8"));
-                        int start = history.size() > 100 ? history.size() - 100 : 0;
-                        for (int i = start; i < history.size(); i++) {
-                            textArea.appendText(history.get(i) + "\n");
-                        }
-                    } catch (NoSuchFileException e) {
-
-                    }
+                    loadHistory(fileName);
                     OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(fileName, true), Charset.forName("UTF-8").newEncoder());
                     while (true) {
                         String str = in.readUTF();

--- a/client/src/main/java/client/Controller.java
+++ b/client/src/main/java/client/Controller.java
@@ -18,11 +18,14 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.Socket;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.ResourceBundle;
 
 public class Controller implements Initializable {
@@ -115,6 +118,17 @@ public class Controller implements Initializable {
                         }
                     }
                     //цикл работы
+                    String fileName = String.format("history_%s.txt", nickname);
+                    try {
+                        List<String> history = Files.readAllLines(Paths.get(fileName), Charset.forName("UTF-8"));
+                        int start = history.size() > 100 ? history.size() - 100 : 0;
+                        for (int i = start; i < history.size(); i++) {
+                            textArea.appendText(history.get(i) + "\n");
+                        }
+                    } catch (NoSuchFileException e) {
+
+                    }
+                    OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(fileName, true), Charset.forName("UTF-8").newEncoder());
                     while (true) {
                         String str = in.readUTF();
                         if (str.startsWith("/")) {
@@ -135,9 +149,11 @@ public class Controller implements Initializable {
                                 textArea.appendText("Ник успешно сменен.\n");
                             }
                         } else {
+                            writer.write(str + "\n");
                             textArea.appendText(str + "\n");
                         }
                     }
+                    writer.close();
                 } catch (RuntimeException e) {
                     System.out.println(e.getMessage());
                 } catch (IOException e) {


### PR DESCRIPTION
1. Добавить в сетевой чат запись локальной истории в текстовый файл на клиенте. Для каждой учетной записи файл с историей должен называться history_[login].txt. (Например, history_login1.txt, history_user111.txt)
2.** После загрузки клиента показывать ему последние 100 строк истории чата.